### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Installation
 
 ```bash
-pnpm add nuxt-mongoose
+npx nuxi@latest module add nuxt-mongoose
 ```
 
 ## Usage

--- a/docs/content/1.docs/1.getting-started/1.setup.md
+++ b/docs/content/1.docs/1.getting-started/1.setup.md
@@ -5,22 +5,9 @@ A Nuxt module for simplifying the use of Mongoose in your project.
 ## Installation
 
 1. Install `nuxt-mongoose` to your dependencies.
-
-::code-group
-
-  ```bash [pnpm]
-  pnpm add nuxt-mongoose -D
-  ```
-
-  ```bash [npm]
-  npm install nuxt-mongoose -D
-  ```
-
-  ```bash [yarn]
-  yarn add nuxt-mongoose -D
-  ```
-
-::
+```bash
+npx nuxi@latest module add nuxt-mongoose
+```
 
 2. Add `nuxt-mongoose` to the `modules` section of your `nuxt.config` file.
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
