### PR TITLE
doc,setup : use nuxt runtime config environment variables api

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can configure the module by adding a `mongoose` section to your `nuxt.config
 ```ts
 export default defineNuxtConfig({
   mongoose: {
-    uri: process.env.MONGODB_URI,
+    uri: process.env.NUXT_MONGOOSE_URI,
     options: {},
     modelsDir: 'models',
   },
@@ -50,12 +50,12 @@ By default, `nuxt-mongoose` will auto-import your schemas from the `models` dire
 If you prefer to use the default configuration, skip adding the `mongoose` section to your `nuxt.config.ts` file. Simply provide your MongoDB connection URI in a `.env` file like this:
 
 ```env
-MONGODB_URI="mongodb+srv://username:password@cluster0.mongodb.net/<database-name>?retryWrites=true&w=majority"
+NUXT_MONGOOSE_URI="mongodb+srv://username:password@cluster0.mongodb.net/<database-name>?retryWrites=true&w=majority"
 ```
 
 > 🔹 Replace `username`, `password`, and `<database name>` with your MongoDB credentials and database name.
 
-That's it! The module will automatically use the `MONGODB_URI` and default settings for your connection. No additional configuration is required.
+That's it! The module will automatically use the `NUXT_MONGOOSE_URI` and default settings for your connection. No additional configuration is required.
 
 ---
 

--- a/playground/.env.example
+++ b/playground/.env.example
@@ -1,1 +1,1 @@
-MONGODB_URI="mongodb://localhost:27017/nuxt-mongoose"
+NUXT_MONGOOSE_URI="mongodb://localhost:27017/nuxt-mongoose"

--- a/src/module.ts
+++ b/src/module.ts
@@ -17,7 +17,7 @@ export interface ModuleOptions {
   /**
    *  The MongoDB URI connection
    *
-   * @default process.env.MONGODB_URI
+   * @default process.env.NUXT_MONGOOSE_URI
    *
    */
   uri: string | undefined
@@ -49,7 +49,7 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: 'mongoose',
   },
   defaults: {
-    uri: String(process.env.MONGODB_URI || ''),
+    uri: String(process.env.NUXT_MONGOOSE_URI || ''),
     devtools: true,
     options: {},
     modelsDir: 'models',
@@ -70,7 +70,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     if (!_options.uri) {
-      logger.warn('Missing MongoDB URI. You can set it in your `nuxt.config` or in your `.env` as `MONGODB_URI`')
+      logger.warn('Missing MongoDB URI. You can set it in your `nuxt.config` or in your `.env` as `NUXT_MONGOOSE_URI`')
     }
 
     const { resolve } = createResolver(import.meta.url)


### PR DESCRIPTION
Aligning environment variables with the Nuxt runtime API.
Nuxt does not recognize environment variables that do not begin with NUXT_.
They are only read at build time, which means that for a production deployment, if you use MONGOOSE_URI in runtime, you will not see them and the connection fail using bad build var.
To avoid future confusion like in #44 or #57 maybe also #68  we need to change the config env from MONGODB_URI to NUXT_MONGOOSE_URI as specified in https://nuxt.com/docs/guide/going-further/runtime-config#environment-variables.