### PR TITLE
fix: restore support for MONGODB_URI alongside NUXT_MONGOOSE_URI in runtime config

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -69,6 +69,9 @@ export default defineNuxtModule<ModuleOptions>({
       }).catch(() => {})
     }
 
+    if (process.env.MONGODB_URI && !process.env.NUXT_MONGOOSE_URI) {
+      logger.warn('`MONGODB_URI` is deprecated, please use `NUXT_MONGOOSE_URI` instead.')
+    }
     if (!_options.uri) {
       logger.warn('Missing MongoDB URI. You can set it in your `nuxt.config` or in your `.env` as `NUXT_MONGOOSE_URI`')
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -49,7 +49,7 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: 'mongoose',
   },
   defaults: {
-    uri: String(process.env.NUXT_MONGOOSE_URI || ''),
+    uri: String(process.env.NUXT_MONGOOSE_URI || process.env.MONGODB_URI || ''),
     devtools: true,
     options: {},
     modelsDir: 'models',


### PR DESCRIPTION
fix breaking change of pr #77 nuxt runtime config,
defaults.uri use new NUXT_MONGOOSE_URI or old MONGODB_URI